### PR TITLE
deduce websocket protocol from page protocol

### DIFF
--- a/src/sagas/event.js
+++ b/src/sagas/event.js
@@ -76,7 +76,8 @@ function* transport(socket) {
 }
 
 function connect() {
-    const socket = new WebSocket(`ws://${location.host}/ws`)
+    const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+    const socket = new WebSocket(`${protocol}//${location.host}/ws`);
 
     const resolver = (resolve, reject) => {
         const timeout = setTimeout(() => {


### PR DESCRIPTION
When nomad-ui running behind https enabled proxy (fabio, nginx) browser disallow connection to http websocket.
This little patch fix this.