### PR TITLE
Add cli flags & remove NOMAD_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ An awesome user interface for an awesome scheduler, plain and simple :-)
 
 Download the latest release from the Github repository and start it with:
 ```
-NOMAD_ADDR=... NOMAD_PORT=4646 ./nomad-ui-${operating system}
+./nomad-ui-${operating system}
 ```
-This will start the nomad-ui server. The frontend can be accessed on port 3000
-by default. You can override this with the PORT environment variable.
+This will start the nomad-ui server. The frontend can be accessed on port `3000`
+by default. You can override this with the `-web.listen-address`.
 
 Another way to run nomad-ui is through Docker. Run the following command to
 start a webserver that will serve the application.
@@ -24,14 +24,13 @@ docker run -e NOMAD_ADDR=... -p 8000:3000 iverberk/nomad-ui:0.1.0
 ```
 Check the releases page on Github to see which version is current.
 
-The user interface will be accessible on localhost, port 8000. Adjust the Docker
+The user interface will be accessible on localhost, port `8000`. Adjust the Docker
 run parameters as needed. If you need to change the port that Nomad is listening
-on, you can use the additional ```-e NOMAD_PORT=...``` environment variable.
+on, you should do it with ```-e NOMAD_ADDR``` environment variable that contains
+both hostname and port.
 
-NOMAD_ADDR (IP or DNS name) and NOMAD_PORT should point to the correct location
-of your Nomad server. It is also possible to specify the listening port for the
-server that is running in the Docker container with ```-e PORT=...```. If you
-have a Node and Go environment you can also build the production version yourself.
+NOMAD_ADDR (IP or DNS name) should point to the correct location of your Nomad server.
+If you have a Node and Go environment you can also build the production version yourself.
 
 1. Build the webapp
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,28 +1,66 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
+	"syscall"
+	"path"
+	"flag"
 )
 
+type Config struct {
+	Address       string
+	ListenAddress string
+	Endpoint      string
+}
+
+func DefaultConfig() *Config {
+	return &Config{
+		Address: "http://127.0.0.1:4646",
+		ListenAddress: ":3000",
+		Endpoint: "/",
+	}
+}
+
+var (
+	flagAddress = flag.String("address", "", "The address of the Nomad server. " +
+		"Overrides the NOMAD_ADDR environment variable if set. " +
+		"(default: \"http://127.0.0.1:4646\")")
+	flagListenAddress = flag.String("web.listen-address", "",
+		"The address on which to expose the web interface. (default: \":3000\")")
+	flagEndpoint = flag.String("web.path", "",
+		"Path under which to expose the web interface. (default: \"/\")")
+)
+
+func (c *Config) Parse() {
+	flag.Parse()
+
+	address, ok := syscall.Getenv("NOMAD_ADDR")
+	if ok {
+		c.Address = address
+	}
+	if *flagAddress != "" {
+		c.Address = *flagAddress
+	}
+	if *flagListenAddress != "" {
+		c.ListenAddress = *flagListenAddress
+	}
+	if *flagEndpoint != "" {
+		c.Endpoint = *flagEndpoint
+	}
+}
+
 func main() {
+	cfg := DefaultConfig()
+	cfg.Parse()
+
 	router := mux.NewRouter()
 
 	broadcast := make(chan *Action)
 
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	if nomadAddr == "" {
-		log.Fatal("Please provide NOMAD_ADDR in the environment, which points to the Nomad server.")
-	}
-	nomadPort := os.Getenv("NOMAD_PORT")
-	if nomadPort == "" {
-		nomadPort = "4646"
-	}
-	nomad := NewNomad(fmt.Sprintf("http://%s:%s", nomadAddr, nomadPort), broadcast)
+	nomad := NewNomad(cfg.Address, broadcast)
 	go nomad.watchAllocs()
 	go nomad.watchEvals()
 	go nomad.watchNodes()
@@ -31,13 +69,9 @@ func main() {
 	hub := NewHub(nomad, broadcast)
 	go hub.Run()
 
-	router.HandleFunc("/ws", hub.Handler)
-	router.PathPrefix("/").Handler(http.FileServer(assetFS()))
+	router.HandleFunc(path.Join(cfg.Endpoint, "ws"), hub.Handler)
+	router.PathPrefix(cfg.Endpoint).Handler(http.FileServer(assetFS()))
 
 	log.Println("Starting server...")
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "3000"
-	}
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), router))
+	log.Fatal(http.ListenAndServe(cfg.ListenAddress, router))
 }


### PR DESCRIPTION
Adding flags is straightforward. Reason for removing NOMAD_PORT was mentioned earlier. Lets have same configuration nomad has. They don't have NOMAD_PORT - we won't too.

Fix https://github.com/iverberk/nomad-ui/issues/18