### PR TITLE
Update icons & rearrange elements

### DIFF
--- a/backend/actions.go
+++ b/backend/actions.go
@@ -22,6 +22,12 @@ const (
 	watchNode    = "WATCH_NODE"
 	unwatchNode  = "UNWATCH_NODE"
 
+	fetchedMembers = "FETCHED_MEMBERS"
+	fetchedMember  = "FETCHED_MEMBER"
+	fetchMember    = "FETCH_MEMBER"
+	watchMember    = "WATCH_MEMBER"
+	unwatchMember  = "UNWATCH_MEMBER"
+
 	fetchDir    = "FETCH_DIR"
 	fetchedDir  = "FETCHED_DIR"
 	watchFile   = "WATCH_FILE"

--- a/backend/main.go
+++ b/backend/main.go
@@ -83,8 +83,9 @@ func main() {
 	nomad := NewNomad(cfg.Address, broadcast)
 	go nomad.watchAllocs()
 	go nomad.watchEvals()
-	go nomad.watchNodes()
 	go nomad.watchJobs()
+	go nomad.watchNodes()
+	go nomad.watchMembers()
 
 	hub := NewHub(nomad, broadcast)
 	go hub.Run()

--- a/backend/nomad.go
+++ b/backend/nomad.go
@@ -4,11 +4,20 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/api"
+	"errors"
+	"fmt"
 )
 
 const (
 	waitTime = 1 * time.Minute
 )
+
+// Wrapper around AgentMember that provides ID field. This is made to keep everything
+// consistent i.e. other types have ID field.
+type AgentMemberWithID struct {
+	api.AgentMember
+	ID string
+}
 
 // Nomad keeps track of the Nomad state. It monitors changes to allocations,
 // evaluations, jobs and nodes and broadcasts them to all connected websockets.
@@ -16,12 +25,44 @@ const (
 type Nomad struct {
 	Client *api.Client
 
-	allocs []*api.AllocationListStub
-	evals  []*api.Evaluation
-	jobs   []*api.JobListStub
-	nodes  []*api.NodeListStub
+	allocs  []*api.AllocationListStub
+	evals   []*api.Evaluation
+	jobs    []*api.JobListStub
+	nodes   []*api.NodeListStub
+	members []*AgentMemberWithID
 
 	updateCh chan *Action
+}
+
+// MembersWithID is used to query all of the known server members.
+func (n *Nomad) MembersWithID() ([]*AgentMemberWithID, error) {
+	members, err := n.Client.Agent().Members()
+	if err != nil {
+		return nil, err
+	}
+
+	ms := make([]*AgentMemberWithID, 0, len(members))
+	for _, m := range members {
+		ms = append(ms, &AgentMemberWithID{
+			AgentMember: *m,
+			ID: m.Name,
+		})
+	}
+	return ms, nil
+}
+
+// MemberWithID is used to query a server member by its ID.
+func (n *Nomad) MemberWithID(ID string) (*AgentMemberWithID, error) {
+	members, err := n.MembersWithID()
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range members {
+		if m.Name == ID {
+			return m, nil
+		}
+	}
+	return nil, errors.New(fmt.Sprintf("Unable to find member with ID: %s", ID))
 }
 
 // NewNomad configures the Nomad API client and initializes the internal state.
@@ -41,6 +82,7 @@ func NewNomad(url string, updateCh chan *Action) *Nomad {
 		allocs:   make([]*api.AllocationListStub, 0),
 		evals:    make([]*api.Evaluation, 0),
 		nodes:    make([]*api.NodeListStub, 0),
+		members:  make([]*AgentMemberWithID, 0),
 		jobs:     make([]*api.JobListStub, 0),
 	}
 }
@@ -52,6 +94,7 @@ func (n *Nomad) FlushAll(c *Connection) {
 	c.send <- &Action{Type: fetchedEvals, Payload: n.evals}
 	c.send <- &Action{Type: fetchedJobs, Payload: n.jobs}
 	c.send <- &Action{Type: fetchedNodes, Payload: n.nodes}
+	c.send <- &Action{Type: fetchedMembers, Payload: n.members}
 }
 
 func (n *Nomad) watchAllocs() {
@@ -135,5 +178,21 @@ func (n *Nomad) watchNodes() {
 			waitIndex = q.WaitIndex
 		}
 		q = &api.QueryOptions{WaitIndex: waitIndex}
+	}
+}
+
+func (n *Nomad) watchMembers() {
+	for {
+		members, err := n.MembersWithID()
+		if err != nil {
+			log.Errorf("watch: unable to fetch members: %s", err)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		n.members = members
+		n.updateCh <- &Action{Type: fetchedMembers, Payload: members}
+
+		time.Sleep(1 * time.Second)
 	}
 }

--- a/src/components/member/info.js
+++ b/src/components/member/info.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+class MemberInfo extends Component {
+
+    render() {
+
+        const memberProps = [
+            "ID",
+            "Name",
+            "Addr",
+            "Port",
+            "Status"
+        ]
+
+        return (
+            <div className="tab-pane active">
+                <div className="content">
+                    <legend>Member Properties</legend>
+                    <dl className="dl-horizontal">
+                        {memberProps.map((memberProp) => {
+                            return (
+                                <div key={memberProp}>
+                                    <dt>{memberProp}</dt>
+                                    <dd>{this.props.member[memberProp]}</dd>
+                                </div>
+                            )
+                        }, this)}
+                    </dl>
+                </div>
+            </div>
+        );
+    }
+}
+
+function mapStateToProps({ member }) {
+    return { member }
+}
+
+export default connect(mapStateToProps)(MemberInfo);

--- a/src/components/member/raw.js
+++ b/src/components/member/raw.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import JSON from '../json'
+
+const MemberRaw = ({ member }) => {
+    return (
+        <div className="tab-pane active">
+            <JSON json={member} />
+        </div>
+    )
+}
+
+function mapStateToProps({ member }) {
+    return { member }
+}
+
+export default connect(mapStateToProps)(MemberRaw)

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -17,6 +17,12 @@ const Sidebar = ({ location }) => {
                             <p>Cluster</p>
                         </Link>
                     </li>
+                    <li className={location.pathname === '/members' ? 'active' : ''}>
+                        <Link to={{ pathname: '/members' }}>
+                            <i className="pe-7s-share" />
+                            <p>Members</p>
+                        </Link>
+                    </li>
                     <li className={location.pathname === '/jobs' ? 'active' : ''}>
                         <Link to={{ pathname: '/jobs' }}>
                             <i className="pe-7s-menu" />

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -23,28 +23,28 @@ const Sidebar = ({ location }) => {
                             <p>Members</p>
                         </Link>
                     </li>
-                    <li className={location.pathname === '/jobs' ? 'active' : ''}>
-                        <Link to={{ pathname: '/jobs' }}>
-                            <i className="pe-7s-menu" />
-                            <p>Jobs</p>
-                        </Link>
-                    </li>
                     <li className={location.pathname === '/nodes' ? 'active' : ''}>
                         <Link to={{ pathname: '/nodes' }}>
-                            <i className="pe-7s-network" />
+                            <i className="pe-7s-keypad" />
                             <p>Nodes</p>
                         </Link>
                     </li>
-                    <li className={location.pathname === '/allocations' ? 'active' : ''}>
-                        <Link to={{ pathname: '/allocations' }}>
-                            <i className="pe-7s-news-paper" />
-                            <p>Allocations</p>
+                    <li className={location.pathname === '/jobs' ? 'active' : ''}>
+                        <Link to={{ pathname: '/jobs' }}>
+                            <i className="pe-7s-copy-file" />
+                            <p>Jobs</p>
                         </Link>
                     </li>
                     <li className={location.pathname === '/evaluations' ? 'active' : ''}>
                         <Link to={{ pathname: '/evaluations' }}>
-                            <i className="pe-7s-science" />
+                            <i className="pe-7s-gleam" />
                             <p>Evaluations</p>
+                        </Link>
+                    </li>
+                    <li className={location.pathname === '/allocations' ? 'active' : ''}>
+                        <Link to={{ pathname: '/allocations' }}>
+                            <i className="pe-7s-graph" />
+                            <p>Allocations</p>
                         </Link>
                     </li>
                 </ul>

--- a/src/containers/member.js
+++ b/src/containers/member.js
@@ -1,0 +1,70 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+import Tabs from '../components/tabs'
+
+import { WATCH_MEMBER, UNWATCH_MEMBER } from '../sagas/event';
+
+class Member extends Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            tabs: [
+                {
+                    name: 'Info',
+                    path: 'info'
+                },
+                {
+                    name: 'Raw',
+                    path: 'raw'
+                }
+            ]
+        }
+    }
+
+    componentWillMount() {
+        this.props.dispatch({
+            type: WATCH_MEMBER,
+            payload: this.props.params['memberId']
+        });
+    }
+
+    componentWillUnmount() {
+        this.props.dispatch({
+            type: UNWATCH_MEMBER,
+            payload: this.props.params['memberId']
+        });
+    }
+
+    render() {
+        if (this.props.member == null) return(null);
+
+        const path = this.props.location.pathname
+        const tabSlug = path.split('/').pop()
+        const basePath = path.substring(0, path.lastIndexOf("/"))
+
+        return (
+            <div className="row">
+                <div className="col-md-12">
+                    <div className="card">
+                        <div className="header">
+                            <h4 className="title">Member: {this.props.member.ID}</h4>
+                        </div>
+                        <div className="content">
+                            <Tabs children={this.props.children} tabs={this.state.tabs} tabSlug={tabSlug} basePath={basePath} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+function mapStateToProps({ member }) {
+    return { member }
+}
+
+
+export default connect(mapStateToProps)(Member)

--- a/src/containers/members.js
+++ b/src/containers/members.js
@@ -1,0 +1,52 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router';
+
+class Members extends Component {
+
+    render() {
+        return (
+            <div className="row">
+                <div className="col-md-12">
+                    <div className="card">
+                        <div className="header">
+                            <h4 className="title">Members</h4>
+                        </div>
+                        <div className="content table-responsive table-full-width">
+                            <table className="table table-hover table-striped">
+                                <thead>
+                                    <tr>
+                                        <th>ID</th>
+                                        <th>Name</th>
+                                        <th>Addr</th>
+                                        <th>Port</th>
+                                        <th>Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {this.props.members.map((member) => {
+                                        return (
+                                            <tr key={member.ID}>
+                                                <td><Link to={`/members/${member.ID}`}>{member.ID}</Link></td>
+                                                <td>{member.Name}</td>
+                                                <td>{member.Addr}</td>
+                                                <td>{member.Port}</td>
+                                                <td>{member.Status}</td>
+                                            </tr>
+                                        )
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+function mapStateToProps({ members }) {
+    return { members }
+}
+
+export default connect(mapStateToProps)(Members)

--- a/src/reducers/member.js
+++ b/src/reducers/member.js
@@ -1,0 +1,19 @@
+import { FETCHED_MEMBERS, FETCHED_MEMBER } from '../sagas/event';
+
+export function MemberInfoReducer(state = {}, action) {
+    switch (action.type) {
+        case FETCHED_MEMBER:
+            return action.payload
+        default:
+    }
+    return state
+}
+
+export function MemberListReducer(state = [], action) {
+    switch (action.type) {
+        case FETCHED_MEMBERS:
+            return action.payload
+        default:
+    }
+    return state
+}

--- a/src/reducers/root.js
+++ b/src/reducers/root.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 
+import { MemberInfoReducer, MemberListReducer } from './member'
 import { JobInfoReducer, JobListReducer } from './job'
 import { AllocInfoReducer, AllocListReducer } from './allocation'
 import { EvalInfoReducer, EvalListReducer } from './evaluation'
@@ -7,6 +8,8 @@ import { NodeInfoReducer, NodeListReducer } from './node'
 import { DirectoryReducer, FileReducer} from './filesystem'
 
 const rootReducer = combineReducers({
+    member: MemberInfoReducer,
+    members: MemberListReducer,
     job: JobInfoReducer,
     jobs: JobListReducer,
     node: NodeInfoReducer,

--- a/src/router.js
+++ b/src/router.js
@@ -27,12 +27,24 @@ import Node from './containers/node';
 import NodeInfo from './components/node/info';
 import NodeRaw from './components/node/raw';
 
+import Members from './containers/members';
+import Member from './containers/member';
+import MemberInfo from './components/member/info';
+import MemberRaw from './components/member/raw';
+
 const AppRouter = () => {
     return (
        <Router history={hashHistory}>
             <Route path="/" component={App}>
                 <IndexRedirect to="/cluster" />
                 <Route path="/cluster" component={Cluster} />
+
+                <Route path="/members" component={Members} />
+                <Route path="/members/:memberId" component={Member}>
+                    <IndexRedirect to="/members/:memberId/info" />
+                    <Route path="/members/:memberId/info" component={MemberInfo} />
+                    <Route path="/members/:memberId/raw" component={MemberRaw} />
+                </Route>
 
                 <Route path="/jobs" component={Jobs} />
                 <Route path="/jobs/:jobId" component={Job}>

--- a/src/sagas/event.js
+++ b/src/sagas/event.js
@@ -6,6 +6,12 @@ export const FETCHED_JOB = 'FETCHED_JOB';
 export const WATCH_JOB = 'WATCH_JOB';
 export const UNWATCH_JOB = 'UNWATCH_JOB';
 
+export const FETCHED_MEMBERS = 'FETCHED_MEMBERS';
+export const FETCHED_MEMBER = 'FETCHED_MEMBER';
+export const FETCH_MEMBER = 'FETCH_MEMBER';
+export const WATCH_MEMBER = 'WATCH_MEMBER';
+export const UNWATCH_MEMBER = 'UNWATCH_MEMBER';
+
 export const FETCHED_NODES = 'FETCHED_NODES';
 export const FETCHED_NODE = 'FETCHED_NODE';
 export const FETCH_NODE = 'FETCH_NODE';
@@ -62,6 +68,9 @@ function* write(socket) {
             WATCH_NODE,
             UNWATCH_NODE,
             FETCH_NODE,
+            WATCH_MEMBER,
+            UNWATCH_MEMBER,
+            FETCH_MEMBER,
             FETCH_DIR,
             WATCH_FILE,
             UNWATCH_FILE,


### PR DESCRIPTION
So, the changes:

*previous* -. *new*

![image](https://cloud.githubusercontent.com/assets/864186/17767381/0f3fdae0-6530-11e6-9add-2da268dd07c4.png) -> ![image](https://cloud.githubusercontent.com/assets/864186/17767346/e87e0026-652f-11e6-8673-c4775c6f3f88.png)

The idea is to group cluster/members/nodes. Icons are changes just because we find them better but hey, very doubtful that you see them the same way:

* jobs represent configurations we feed
* evaluations are kind of events that happen so we use event icon
* allocations is something that persists for a while so we use pie chart to remind that they allocate parts of something

If you have a better mental model behind current icons, please share! I'm trying to find something that will be kind of obvious without learning what nomad is.

P.S. Add members commit here is simply to make sure it will merge.
