### PR TITLE
Implement fake UUID for every member in members

### DIFF
--- a/backend/glide.yaml
+++ b/backend/glide.yaml
@@ -18,3 +18,5 @@ import:
   version: 3.0.7
 - package: github.com/elazarl/go-bindata-assetfs
   version: 41022e9a1e5b0e5d7139533d57467a06bcbc857f
+- package: github.com/satori/go.uuid
+  version: ~1.1.0

--- a/backend/nomad.go
+++ b/backend/nomad.go
@@ -80,8 +80,7 @@ func (n *Nomad) MembersWithID() ([]*AgentMemberWithID, error) {
 	for _, m := range members {
 		x, err := NewAgentMemberWithID(m)
 		if err != nil {
-			log.Errorf("Failed to create AgentMemberWithID %s: %#v", err, m)
-			continue
+			return nil, errors.New(fmt.Sprintf("Failed to create AgentMemberWithID %s: %#v", err, m))
 		}
 		ms = append(ms, x)
 	}

--- a/src/containers/members.js
+++ b/src/containers/members.js
@@ -27,7 +27,7 @@ class Members extends Component {
                                     {this.props.members.map((member) => {
                                         return (
                                             <tr key={member.ID}>
-                                                <td><Link to={`/members/${member.ID}`}>{member.ID}</Link></td>
+                                                <td><Link to={`/members/${member.ID}`}>{member.ID.substring(0,8)}</Link></td>
                                                 <td>{member.Name}</td>
                                                 <td>{member.Addr}</td>
                                                 <td>{member.Port}</td>


### PR DESCRIPTION
While it is not an actual ID, now it is at least more or less unique per every member and formatted as a proper UUID. This makes it easier for webapp as it treats it same as everywhere.