### PR TITLE
Do not use -t flag on install command (does not exist on OSX)

### DIFF
--- a/3rdparty/Makefile
+++ b/3rdparty/Makefile
@@ -53,7 +53,7 @@ build: $(BUILD_DIR)/go-bindata $(BUILD_DIR)/go-bindata-assetfs $(BUILD_DIR)/glid
 
 .PHONY: install
 install: $(BUILD_DIR)/go-bindata $(BUILD_DIR)/go-bindata-assetfs $(BUILD_DIR)/glide
-	install -m 0755 -t $(DESTDIR) $?
+	install -m 0755 $? $(DESTDIR)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build: webpack nomad-ui
 
 .PHONY: install
 install: build
-	install -m 0755 -t $(DESTDIR) $(shell ls $(BUILD_DIR)/nomad-ui-*)
+	install -m 0755  $(shell ls $(BUILD_DIR)/nomad-ui-*) $(DESTDIR)
 
 .PHONY: vet
 vet:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -42,7 +42,7 @@ build: $(BINARIES)
 
 .PHONY: install
 install: $(BINARIES)
-	install -m 0755 -t $(DESTDIR) $?
+	install -m 0755 $? $(DESTDIR)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
/cc @themalkolm The -t flag does not exist on OSX. I've removed it and added the destination directory at the end of the command. Although I know that you don't have budget for Makefiles any more this week, are there any downsides to doing this? :-)