### PR TITLE
Listen on all interfaces.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "webpack-dev-server": ".bin/webpack-dev-server"
   },
   "scripts": {
-    "start": "webpack-dev-server",
+    "start": "webpack-dev-server --host 0.0.0.0",
     "build": "webpack --config webpack-prod.config.js -p --progress"
   },
   "keywords": [


### PR DESCRIPTION
This makes it possible to use dev server inside vagrant box i.e.
with vagrant port mapping. Otherwise it won't work.