### PR TITLE
Add taskGroup & tasks tabs to job.

### DIFF
--- a/src/components/job/taskGroups.js
+++ b/src/components/job/taskGroups.js
@@ -1,0 +1,75 @@
+import React, {Component} from "react";
+import {connect} from "react-redux";
+import {Link} from "react-router";
+import Table from "../table";
+import shortUUID from "../uuid";
+import JSON from "../json";
+
+class JobTaskGroups extends Component {
+    render() {
+        const job = this.props.job;
+
+        const taskGroups = [];
+        const taskGroupHeaders = [
+            "ID",
+            "Name",
+            "Count",
+            "Constraints",
+            "Meta",
+            "Restart Policy",
+        ];
+        job.TaskGroups.forEach((taskGroup) => {
+            taskGroup.ID = taskGroup.Name;
+            taskGroups.push(
+                <tr key={taskGroup.ID}>
+                    <td><Link to={`/jobs/${job.ID}/taskGroups`}
+                              query={{taskGroupId: taskGroup.ID}}>{shortUUID(taskGroup.ID)}</Link></td>
+                    <td>{taskGroup.Name}</td>
+                    <td>{taskGroup.Count}</td>
+                    <td>{taskGroup.Constraints || "<none>"}</td>
+                    <td>{taskGroup.Meta || "<none>" }</td>
+                    <td>{taskGroup.RestartPolicy.Mode}</td>
+                </tr>
+            )
+        });
+
+        let taskGroupId = this.props.location.query['taskGroupId'];
+
+        //
+        // Auto-select first task group if only one is available.
+        //
+        if (!taskGroupId && job.TaskGroups.length === 1) {
+            taskGroupId = job.TaskGroups[0].ID;
+        }
+        return (
+            <div className="tab-pane active">
+                <div className="row">
+                    <div className="col-md-6">
+                        <legend>Task Groups</legend>
+                        {(taskGroups.length > 0) ?
+                            <Table classes="table table-hover table-striped" headers={taskGroupHeaders}
+                                   body={taskGroups}/>
+                            : null
+                        }
+                    </div>
+                    <div className="col-md-4">
+                        <legend>Task Group: {taskGroupId}</legend>
+                        {job.TaskGroups.filter((taskGroup) => {
+                            return taskGroup.ID === taskGroupId
+                        }).map((taskGroup) => {
+                            return (
+                                <JSON json={taskGroup}/>
+                            )
+                        }).pop()}
+                    </div>
+                </div>
+            </div>
+        )
+    }
+}
+
+function mapStateToProps({job}) {
+    return {job}
+}
+
+export default connect(mapStateToProps)(JobTaskGroups);

--- a/src/components/job/tasks.js
+++ b/src/components/job/tasks.js
@@ -1,0 +1,91 @@
+import React, {Component} from "react";
+import {connect} from "react-redux";
+import {Link} from "react-router";
+import Table from "../table";
+import shortUUID from "../uuid";
+import JSON from "../json";
+
+class JobTasks extends Component {
+    render() {
+        const job = this.props.job;
+
+        const tasks = [];
+        const taskHeaders = [
+            "ID",
+            "Name",
+            "Group",
+            "Driver",
+            "CPU",
+            "Memory",
+            "Disk",
+        ];
+        job.TaskGroups.forEach((taskGroup) => {
+            taskGroup.Tasks.forEach((task) => {
+                task.ID = task.Name;
+                taskGroup.ID = taskGroup.Name;
+                tasks.push(
+                    <tr key={task.ID}>
+                        <td><Link to={`/jobs/${job.ID}/tasks`}
+                                  query={{taskGroupId: taskGroup.ID, taskId: task.ID}}>{shortUUID(task.ID)}</Link>
+                        </td>
+                        <td>{task.Name}</td>
+                        <td><Link to={`/jobs/${job.ID}/taskGroups`}
+                                  query={{taskGroupId: taskGroup.ID}}>{shortUUID(taskGroup.ID)}</Link></td>
+                        <td>{task.Driver}</td>
+                        <td>{task.Resources.CPU}</td>
+                        <td>{task.Resources.MemoryMB}</td>
+                        <td>{task.Resources.DiskMB}</td>
+                    </tr>
+                )
+            })
+        });
+
+        let taskGroupId = this.props.location.query['taskGroupId'];
+        let taskId = this.props.location.query['taskId'];
+
+        //
+        // Auto-select first task if only one is available.
+        //
+        if (!taskGroupId && !taskId && tasks.length === 1) {
+            job.TaskGroups.forEach((taskGroup) => {
+                taskGroup.Tasks.forEach((task) => {
+                    taskGroupId = taskGroup.ID;
+                    taskId = task.ID;
+                })
+            })
+        }
+        return (
+            <div className="tab-pane active">
+                <div className="row">
+                    <div className="col-md-6">
+                        <legend>Tasks</legend>
+                        {(tasks.length > 0) ?
+                            <Table classes="table table-hover table-striped" headers={taskHeaders} body={tasks}/>
+                            : null
+                        }
+                    </div>
+                    <div className="col-md-4">
+                        <legend>Task: { (taskGroupId && taskId) ? taskGroupId + '/' + taskId : null}</legend>
+                        {this.props.job.TaskGroups.filter((taskGroup) => {
+                            return taskGroup.ID === taskGroupId
+                        }).map((taskGroup) => {
+                            return taskGroup.Tasks.filter((task) => {
+                                return task.ID === taskId
+                            }).map((task) => {
+                                return (
+                                    <JSON json={task}/>
+                                )
+                            }).pop()
+                        }).pop()}
+                    </div>
+                </div>
+            </div>
+        )
+    }
+}
+
+function mapStateToProps({job}) {
+    return {job}
+}
+
+export default connect(mapStateToProps)(JobTasks);

--- a/src/components/uuid.js
+++ b/src/components/uuid.js
@@ -1,0 +1,10 @@
+function shortUUID(ID) {
+	let re = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
+	if (ID.match(re)) {
+		return ID.substring(0, 8)
+	} else {
+		return ID
+	}
+}
+
+export default shortUUID

--- a/src/containers/job.js
+++ b/src/containers/job.js
@@ -25,6 +25,14 @@ class Job extends Component {
                     path: 'evaluations'
                 },
                 {
+                    name: 'Tasks Groups',
+                    path: 'taskGroups'
+                },
+                {
+                    name: 'Tasks',
+                    path: 'tasks'
+                },
+                {
                     name: 'Raw',
                     path: 'raw'
                 }

--- a/src/router.js
+++ b/src/router.js
@@ -9,6 +9,8 @@ import Job from './containers/job';
 import JobInfo from './components/job/info';
 import JobAllocs from './components/job/allocs';
 import JobEvals from './components/job/evals';
+import JobTasks from './components/job/tasks';
+import JobTaskGroups from './components/job/taskGroups';
 import JobRaw from './components/job/raw';
 
 import Allocations from './containers/allocations';
@@ -52,6 +54,8 @@ const AppRouter = () => {
                     <Route path="/jobs/:jobId/info" component={JobInfo} />
                     <Route path="/jobs/:jobId/allocations" component={JobAllocs} />
                     <Route path="/jobs/:jobId/evaluations" component={JobEvals} />
+                    <Route path="/jobs/:jobId/tasks" component={JobTasks} />
+                    <Route path="/jobs/:jobId/taskGroups" component={JobTaskGroups} />
                     <Route path="/jobs/:jobId/raw" component={JobRaw} />
                 </Route>
 


### PR DESCRIPTION
So, we add new tabs to job to allow it click, click, click through the configuration easier. While it is not perfect - we are getting there. Now it is easy to get grasp how many groups & tasks you have for every job. 

We can add nice views for task & task group later. JSON works for now.

**New tabs**

![image](https://cloud.githubusercontent.com/assets/864186/17812236/777c5470-6626-11e6-8697-b7f6b96271c6.png)

**Task Groups**

With single element we automatically select first task group and show its content on right.

![image](https://cloud.githubusercontent.com/assets/864186/17812250/849488da-6626-11e6-897e-fa9a7743f04b.png)

**Tasks**

We don't select anything by default. Simply list tasks.

![image](https://cloud.githubusercontent.com/assets/864186/17812260/8be8b840-6626-11e6-9c38-b943553a8ad8.png)

**Tasks**

Here we clicked on first task and now it is displayed to the right. Dunno how to correctly highlight table row - need help.

![image](https://cloud.githubusercontent.com/assets/864186/17812269/975ce2f0-6626-11e6-9607-558fcef4ace3.png)
