### PR TITLE
Use better key for events table.

### DIFF
--- a/src/containers/events.js
+++ b/src/containers/events.js
@@ -11,8 +11,9 @@ class Events extends Component {
                 Object.keys(allocation.TaskStates).forEach((task) => {
                     allocation.TaskStates[task].Events.reverse().forEach((event) => {
                         if (taskEvents.length === 10) return
+                        let eventID = task + '.' + event.Time
                         taskEvents.push(
-                            <tr key={event.Time}>
+                            <tr key={eventID}>
                                 <td>{task}</td>
                                 <td>{event.Type}</td>
                                 <td>{event.KillError || event.DriverError || event.DownloadError || event.RestartReason || event.Message || "<none>" }</td>


### PR DESCRIPTION
Event is not unique by its time. It is possible to receive same
event for two tasks with the same timestamp.