### PR TITLE
Run jslint as before_script in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ before_install:
   - cd ${HOME}/gopath/src/${GOPKG}
   - go version
 
+before_script:
+  - make lint
+
 script:
   - GOBUILD=${GOBUILD} make all
   - ls -la build

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,11 @@ fmt:
 simplify:
 	gofmt -l -s -w $(GOFILES_NOVENDOR)
 
+.PHONY: lint
+lint:
+	@test -e node_modules || npm install
+	npm run-script lint
+
 .PHONY: clean
 clean:
 	@echo "=> cleaning ..."

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "main": "src/main.js",
   "bin": {
     "webpack": ".bin/webpack",
-    "webpack-dev-server": ".bin/webpack-dev-server"
+    "webpack-dev-server": ".bin/webpack-dev-server",
+    "eslint": ".bin/eslint"
   },
   "scripts": {
     "start": "webpack-dev-server --host 0.0.0.0",
-    "build": "webpack --config webpack-prod.config.js -p --progress"
+    "build": "webpack --config webpack-prod.config.js -p --progress",
+    "lint": "eslint -c config/eslint.js src"
   },
   "keywords": [
     "nomad"


### PR DESCRIPTION
This way we can configure travis to deny requests that do not conform to linter's configuration.