### PR TITLE
Allow dynamic listen port from nomad

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -59,9 +59,16 @@ func (c *Config) Parse() {
 	if ok {
 		c.Address = address
 	}
+
+	listenPort, ok := syscall.Getenv("NOMAD_PORT_http")
+	if ok {
+		c.ListenAddress = fmt.Sprintf("0.0.0.0:%s", listenPort)
+	}
+
 	if *flagAddress != "" {
 		c.Address = *flagAddress
 	}
+
 	if *flagListenAddress != "" {
 		c.ListenAddress = *flagListenAddress
 	}

--- a/nomad-ui.nomad
+++ b/nomad-ui.nomad
@@ -64,10 +64,13 @@ job "nomad-ui" {
         network {
           mbits = 10
 
-          # request for a dynamic port
+          # request for a static port
           port "http" {
             static = 3000
           }
+
+          # use a dynamic port
+          # port "http" {}
         }
       }
     }


### PR DESCRIPTION
  * Add NOMAD_PORT_http to allow dynamic listen port from nomad jobs
  * Add example in nomad-ui.nomad