### PR TITLE
Align naming with docs (member->server, node->client)

### DIFF
--- a/frontend/assets/sass/nomad-ui.scss
+++ b/frontend/assets/sass/nomad-ui.scss
@@ -55,6 +55,10 @@
 	}
 }
 
+body {
+	background-color: #EFEFEF;
+}
+
 .pointer {
 	cursor: pointer;
 }

--- a/frontend/assets/sass/nomad-ui/_sidebar-and-main-panel.scss
+++ b/frontend/assets/sass/nomad-ui/_sidebar-and-main-panel.scss
@@ -9,10 +9,10 @@
     color: #fff;
     font-weight: 200;
 
-
-    .sidebar-wrapper{
+    .sidebar-wrapper {
         position: relative;
         z-index: 4;
+
 
         height: calc(100vh - 64px);
 
@@ -30,7 +30,7 @@
 
     }
 
-    .sidebar-background{
+    .sidebar-background {
         background-image: url('../img/nomad.jpg');
         position: absolute;
         z-index: 1;
@@ -39,8 +39,7 @@
         display: block;
         top: 0;
         left: 0;
-        background-size: cover;
-        background-position: center center;
+        background-position: left top;
     }
 
     .nav{
@@ -188,7 +187,6 @@
     }
 
     &:after{
-       @include line-gradient($black-color-top, rgba($black-color-bottom,.7));
        z-index: 3;
        opacity: 1;
     }
@@ -209,7 +207,8 @@
         @include line-gradient($color-green, rgba($green-color-bottom,.7));
     }
     &[data-color="nomad-green"]:after{
-        @include line-gradient($color-nomad-green, rgba($nomad-green-color-bottom,.7));
+        opacity: 0.8;
+        background-color: $color-nomad-green;
     }
     &[data-color="orange"]:after{
         @include line-gradient($color-orange, rgba($orange-color-bottom,.7));

--- a/frontend/assets/sass/nomad-ui/mixins/_vendor-prefixes.scss
+++ b/frontend/assets/sass/nomad-ui/mixins/_vendor-prefixes.scss
@@ -135,14 +135,14 @@
       75% { transform: rotate(5deg); }
       100% { top: 0px; transform: rotate(0); }
     }
-    
+
     @-webkit-keyframes topbar-back {
       0% { top: 6px; -webkit-transform: rotate(135deg); }
       45% { -webkit-transform: rotate(-10deg); }
       75% { -webkit-transform: rotate(5deg); }
       100% { top: 0px; -webkit-transform: rotate(0); }
     }
-    
+
     @-moz-keyframes topbar-back {
       0% { top: 6px; -moz-transform: rotate(135deg); }
       45% { -moz-transform: rotate(-10deg); }

--- a/frontend/index.html.ejs
+++ b/frontend/index.html.ejs
@@ -39,8 +39,8 @@
 <% } %>
 
 <% if (htmlWebpackPlugin.options.appMountId) { %>
-<div class="wrapper">
-    <div id="<%= htmlWebpackPlugin.options.appMountId%>"></div>
+<div class="container-fluid">
+  <div id="<%= htmlWebpackPlugin.options.appMountId%>" class="row"></div>
 </div>
 <% } %>
 

--- a/frontend/index.html.ejs
+++ b/frontend/index.html.ejs
@@ -39,8 +39,7 @@
 <% } %>
 
 <% if (htmlWebpackPlugin.options.appMountId) { %>
-<div class="container-fluid">
-  <div id="<%= htmlWebpackPlugin.options.appMountId%>" class="row"></div>
+<div class="container-fluid" id="app">
 </div>
 <% } %>
 

--- a/frontend/src/components/_constraint/constraint_row.js
+++ b/frontend/src/components/_constraint/constraint_row.js
@@ -4,19 +4,18 @@ class ConstraintRow extends Component {
 
     render() {
         const constraint = this.props.constraint;
-        const uniqueKey = constraint.LTarget + '@' + constraint.RTarget + '@' + constraint.Operand;
 
         // unique case as it does not expose any LTarget or RTarget
         if (constraint.Operand === 'distinct_hosts') {
             return (
-                <tr key={uniqueKey}>
+                <tr>
                     <td colSpan="3"><code>Distinct Hosts</code></td>
                 </tr>
             )
         }
 
         return (
-            <tr key={uniqueKey}>
+            <tr>
                 <td><code>{constraint.LTarget}</code></td>
                 <td>{constraint.Operand}</td>
                 <td><code>{constraint.RTarget}</code></td>
@@ -26,7 +25,7 @@ class ConstraintRow extends Component {
 }
 
 ConstraintRow.defaultProps = {
-    constraint: {}
+    constraint: {},
 };
 
 export default ConstraintRow

--- a/frontend/src/components/_constraint/constraint_row.js
+++ b/frontend/src/components/_constraint/constraint_row.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+
+class ConstraintRow extends Component {
+
+    render() {
+        const constraint = this.props.constraint;
+        const uniqueKey = constraint.LTarget + '@' + constraint.RTarget + '@' + constraint.Operand;
+
+        // unique case as it does not expose any LTarget or RTarget
+        if (constraint.Operand === 'distinct_hosts') {
+            return (
+                <tr key={uniqueKey}>
+                    <td colSpan="3"><code>Distinct Hosts</code></td>
+                </tr>
+            )
+        }
+
+        return (
+            <tr key={uniqueKey}>
+                <td><code>{constraint.LTarget}</code></td>
+                <td>{constraint.Operand}</td>
+                <td><code>{constraint.RTarget}</code></td>
+            </tr>
+        )
+    }
+}
+
+ConstraintRow.defaultProps = {
+    constraint: {}
+};
+
+export default ConstraintRow

--- a/frontend/src/components/_constraint/constraint_table.js
+++ b/frontend/src/components/_constraint/constraint_table.js
@@ -4,6 +4,10 @@ import ReactTooltip from 'react-tooltip'
 
 class ConstraintTable extends Component {
 
+    getUniqueKeyForConstraint(constraint) {
+        return (constraint.LTarget + '@' + constraint.RTarget + '@' + constraint.Operand)
+    }
+
     render() {
         if (this.props.constraints === null || this.props.constraints.length === 0) {
             return (<span>-</span>)
@@ -20,7 +24,7 @@ class ConstraintTable extends Component {
             </thead>
             <tbody>
                 {this.props.constraints.map((constraint) => {
-                    return (<ConstraintRow constraint={constraint} />)
+                    return (<ConstraintRow key={this.getUniqueKeyForConstraint(constraint)} idPrefix={this.props.idPrefix} constraint={constraint} />)
                 })}
             </tbody>
             </table>

--- a/frontend/src/components/_constraint/constraint_table.js
+++ b/frontend/src/components/_constraint/constraint_table.js
@@ -1,0 +1,48 @@
+import React, { Component } from 'react';
+import ConstraintRow from './constraint_row';
+import ReactTooltip from 'react-tooltip'
+
+class ConstraintTable extends Component {
+
+    render() {
+        if (this.props.constraints === null || this.props.constraints.length === 0) {
+            return (<span>-</span>)
+        }
+
+        const table = (
+            <table className={'table table-hover ' + (this.props.asTooltip ? '' : 'table-striped')}>
+            <thead>
+                <tr>
+                    <th>Key</th>
+                    <th>Operand</th>
+                    <th>Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {this.props.constraints.map((constraint) => {
+                    return (<ConstraintRow constraint={constraint} />)
+                })}
+            </tbody>
+            </table>
+        )
+
+        if (this.props.asTooltip) {
+            return (
+                <div>
+                    <ReactTooltip id={'tooltip-constraints-' + this.props.idPrefix}>{table}</ReactTooltip>
+                    <span data-tip data-for={'tooltip-constraints-' + this.props.idPrefix} className="dotted">{this.props.constraints.length} constraints</span>
+                </div>
+            )
+        }
+
+        return table
+    }
+}
+
+ConstraintTable.defaultProps = {
+    constraints: [],
+    asTooltip: false,
+    idPrefix: null,
+};
+
+export default ConstraintTable

--- a/frontend/src/components/allocation_list.js
+++ b/frontend/src/components/allocation_list.js
@@ -63,9 +63,9 @@ class AllocationList extends Component {
                     <th>Job</th>
                     <th>Task Group</th>
                     <th>Task</th>
+                    <th>Client</th>
                     <th>Client Status</th>
                     <th>Desired Status</th>
-                    <th>Node</th>
                     <th>Evaluation</th>
                     <th>Time</th>
                 </tr>
@@ -79,9 +79,9 @@ class AllocationList extends Component {
                             <td><NomadLink jobId={allocation.JobID} short="true" /></td>
                             <td><NomadLink jobId={allocation.JobID} taskGroupId={allocation.TaskGroupId}>{allocation.TaskGroup}</NomadLink></td>
                             <td>{allocation.Name}</td>
+                            <td><NomadLink nodeId={allocation.NodeID} nodeList={this.props.nodes} short="true" /></td>
                             <td>{this.renderClientStatus(allocation)}</td>
                             <td>{this.renderDesiredStatus(allocation)}</td>
-                            <td><NomadLink nodeId={allocation.NodeID} nodeList={this.props.nodes} short="true" /></td>
                             <td><NomadLink evalId={allocation.EvalID} short="true" /></td>
                             <td><DisplayTime time={allocation.CreateTime} /></td>
                         </tr>

--- a/frontend/src/components/app.js
+++ b/frontend/src/components/app.js
@@ -3,9 +3,9 @@ import Sidebar from './sidebar'
 
 const App = ({ location, children }) => {
     return (
-        <div>
+        <div className="row">
             <Sidebar location={ location} />
-            <div className="main-panel">
+            <div className="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main-panel">
                 <div className="content">
                     <div className="container-fluid">
                     { children }

--- a/frontend/src/components/client/info.js
+++ b/frontend/src/components/client/info.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-class NodeInfo extends Component {
+class ClientInfo extends Component {
 
     render() {
 
@@ -18,7 +18,7 @@ class NodeInfo extends Component {
         return (
             <div className="tab-pane active">
                 <div className="content">
-                    <legend>Node Properties</legend>
+                    <legend>Client Properties</legend>
                     <dl className="dl-horizontal">
                         {nodeProps.map((nodeProp) => {
                             return (
@@ -39,4 +39,4 @@ function mapStateToProps({ node }) {
     return { node }
 }
 
-export default connect(mapStateToProps)(NodeInfo);
+export default connect(mapStateToProps)(ClientInfo);

--- a/frontend/src/components/client/raw.js
+++ b/frontend/src/components/client/raw.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import JSON from '../json'
 
-const NodeRaw = ({ node }) => {
+const ClientRaw = ({ node }) => {
     return (
         <div className="tab-pane active">
             <JSON json={node} />
@@ -15,4 +15,4 @@ function mapStateToProps({ node }) {
     return { node }
 }
 
-export default connect(mapStateToProps)(NodeRaw)
+export default connect(mapStateToProps)(ClientRaw)

--- a/frontend/src/components/job/info.js
+++ b/frontend/src/components/job/info.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { NomadLink } from '../link';
 import Table from '../table'
 import MetaDisplay from '../meta'
+import ConstraintTable from '../_constraint/constraint_table'
 
 class JobInfo extends Component {
 
@@ -18,14 +19,15 @@ class JobInfo extends Component {
                         <td><NomadLink jobId={job.ID} taskGroupId={taskGroup.ID}>{taskGroup.Name}</NomadLink></td>
                         <td><NomadLink jobId={job.ID} taskGroupId={taskGroup.ID} taskId={task.ID}>{task.Name}</NomadLink></td>
                         <td>{task.Driver}</td>
-                        <td>{task.Resources.CPU}</td>
-                        <td>{task.Resources.MemoryMB}</td>
-                        <td>{task.Resources.DiskMB}</td>
+                        <td>{task.Resources.CPU} MHz</td>
+                        <td>{task.Resources.MemoryMB} MB</td>
+                        <td>{task.Resources.DiskMB} MB</td>
+                        <td><ConstraintTable idPrefix={task.ID} asTooltip={true} constraints={task.Constraints} /></td>
                     </tr>
                 )
+
                 return null
             })
-
             return (
                 <tr key={taskGroup.ID}>
                     <td><NomadLink jobId={job.ID} taskGroupId={taskGroup.ID}>{taskGroup.Name}</NomadLink></td>
@@ -33,6 +35,7 @@ class JobInfo extends Component {
                     <td>{taskGroup.Tasks.length}</td>
                     <td><MetaDisplay asTooltip={true} metaBag={taskGroup.Meta} /></td>
                     <td>{taskGroup.RestartPolicy.Mode}</td>
+                    <td><ConstraintTable idPrefix={taskGroup.ID} asTooltip={true} constraints={taskGroup.Constraints} /></td>
                 </tr>
             )
         })
@@ -67,18 +70,32 @@ class JobInfo extends Component {
                             <MetaDisplay dtWithClass="wide" metaBag={this.props.job.Meta} />
                         </div>
                     </div>
+
+                    <br />
+                    <br />
+
+                    <div className="row">
+                        <div className="col-lg-6 col-md-6 col-sm-12 col-sx-12">
+                            <legend>Constraints</legend>
+                            <ConstraintTable idPrefix={this.props.job.ID} constraints={this.props.job.Constraints} />
+                        </div>
+                    </div>
+
+                    <br />
                     <br />
 
                     <legend>Task Groups</legend>
                     {(taskGroups.length > 0) ?
-                        <Table classes="table table-hover table-striped" headers={["Name", "Count", "Tasks", "Meta", "Restart Policy" ]} body={taskGroups} />
+                        <Table classes="table table-hover table-striped" headers={["Name", "Count", "Tasks", "Meta", "Restart Policy", "Constraints" ]} body={taskGroups} />
                         : null
                     }
 
-                    <br /><br />
+                    <br />
+                    <br />
+
                     <legend>Tasks</legend>
                     {(tasks.length > 0) ?
-                        <Table classes="table table-hover table-striped" headers={["Task Group", "Name", "Driver", "CPU", "Memory", "Disk" ]} body={tasks} />
+                        <Table classes="table table-hover table-striped" headers={["Task Group", "Name", "Driver", "CPU", "Memory", "Disk", "Constraints" ]} body={tasks} />
                         : null
                     }
                 </div>
@@ -86,6 +103,15 @@ class JobInfo extends Component {
         );
     }
 }
+
+JobInfo.defaultProps = {
+    job: {
+        constraints: []
+    },
+    allocations: {},
+    evaluations: {},
+};
+
 
 function mapStateToProps({ job, allocations, evaluations }) {
     return { job, allocations, evaluations }

--- a/frontend/src/components/link.js
+++ b/frontend/src/components/link.js
@@ -31,7 +31,7 @@ export class NomadLink extends Component {
                 children = short ? shortUUID(memberId) : memberId
             }
             return (
-                <Link {...linkProps} to={`/members/${memberId}`}>{children}</Link>
+                <Link {...linkProps} to={`/servers/${memberId}`}>{children}</Link>
             )
         }
 
@@ -46,7 +46,7 @@ export class NomadLink extends Component {
                 }
             }
             return (
-                <Link {...linkProps} to={`/nodes/${nodeId}`}>{children}</Link>
+                <Link {...linkProps} to={`/clients/${nodeId}`}>{children}</Link>
             )
         }
 

--- a/frontend/src/components/meta.js
+++ b/frontend/src/components/meta.js
@@ -12,7 +12,7 @@ class MetaDisplay extends Component {
 
         let keys = Object.keys(metaBag || {});
         if (keys.length === 0) {
-            return (<span>-none-</span>);
+            return (<span>-</span>);
         }
 
         let identifier = uuid.v1();

--- a/frontend/src/components/server/info.js
+++ b/frontend/src/components/server/info.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import Table from '../table'
 
-class MemberInfo extends Component {
+class ServerInfo extends Component {
 
     render() {
 
@@ -31,7 +31,7 @@ class MemberInfo extends Component {
         return (
             <div className="tab-pane active">
                 <div className="content">
-                    <legend>Member Properties</legend>
+                    <legend>Server Properties</legend>
                     <dl className="dl-horizontal">
                         {memberProps.map((memberProp) => {
                             return (
@@ -43,7 +43,7 @@ class MemberInfo extends Component {
                         }, this)}
                     </dl>
                     <br />
-                    <legend>Member Tags</legend>
+                    <legend>Server Tags</legend>
                     {(memberTags.length > 0) ?
                         <Table classes="table table-hover table-striped" headers={["Name", "Value"]} body={memberTags} />
                         : null
@@ -58,4 +58,4 @@ function mapStateToProps({ member }) {
     return { member }
 }
 
-export default connect(mapStateToProps)(MemberInfo);
+export default connect(mapStateToProps)(ServerInfo);

--- a/frontend/src/components/server/raw.js
+++ b/frontend/src/components/server/raw.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import JSON from '../json'
 
-const MemberRaw = ({ member }) => {
+const ServerRaw = ({ member }) => {
     return (
         <div className="tab-pane active">
             <JSON json={member} />
@@ -15,4 +15,4 @@ function mapStateToProps({ member }) {
     return { member }
 }
 
-export default connect(mapStateToProps)(MemberRaw)
+export default connect(mapStateToProps)(ServerRaw)

--- a/frontend/src/components/sidebar.js
+++ b/frontend/src/components/sidebar.js
@@ -3,13 +3,13 @@ import { Link } from 'react-router';
 
 const Sidebar = ({ location }) => {
     return (
-        <div className="sidebar" data-color="nomad-green" data-image="assets/img/nomad.jpg">
+        <div className="col-sm-3 col-md-2 sidebar" data-color="nomad-green">
+            <div className="logo">
+                <Link to={{ pathname: '/cluster' }} className="logo-text" >
+                    Nomad
+                </Link>
+            </div>
             <div className="sidebar-wrapper">
-                <div className="logo">
-                    <Link to={{ pathname: '/cluster' }} className="logo-text" >
-                        Nomad
-                    </Link>
-                </div>
                 <ul className="nav">
                     <li className={location.pathname.startsWith('/cluster') ? 'active' : ''}>
                         <Link to={{ pathname: '/cluster' }}>
@@ -35,16 +35,16 @@ const Sidebar = ({ location }) => {
                             <p>Evaluations</p>
                         </Link>
                     </li>
-                    <li className={location.pathname.startsWith('/members') ? 'active' : ''}>
-                        <Link to={{ pathname: '/members' }}>
-                            <i className="pe-7s-share" />
-                            <p>Members</p>
+                    <li className={location.pathname.startsWith('/clients') ? 'active' : ''}>
+                        <Link to={{ pathname: '/clients' }}>
+                            <i className="pe-7s-keypad" />
+                            <p>Clients</p>
                         </Link>
                     </li>
-                    <li className={location.pathname.startsWith('/nodes') ? 'active' : ''}>
-                        <Link to={{ pathname: '/nodes' }}>
-                            <i className="pe-7s-keypad" />
-                            <p>Nodes</p>
+                    <li className={location.pathname.startsWith('/servers') ? 'active' : ''}>
+                        <Link to={{ pathname: '/servers' }}>
+                            <i className="pe-7s-share" />
+                            <p>Servers</p>
                         </Link>
                     </li>
                 </ul>

--- a/frontend/src/components/time.js
+++ b/frontend/src/components/time.js
@@ -41,10 +41,10 @@ class DisplayTime extends Component {
 		const format = this.props.timeFormat;
 
 		if (this.props.display === "relative") {
-			return <div className="dotted" title={time.format(format)}>{this.getTimeDiff(time, now)}</div>
+			return <span className="dotted" title={time.format(format)}>{this.getTimeDiff(time, now)}</span>
 		}
 
-		return <div className="dotted" title={this.getTimeDiff(time, now)}>{time.format(format)}</div>
+		return <span className="dotted" title={this.getTimeDiff(time, now)}>{time.format(format)}</span>
 	}
 }
 

--- a/frontend/src/containers/client.js
+++ b/frontend/src/containers/client.js
@@ -5,7 +5,7 @@ import Tabs from '../components/tabs'
 
 import { WATCH_NODE, UNWATCH_NODE } from '../sagas/event';
 
-class Node extends Component {
+class Client extends Component {
 
     constructor(props) {
         super(props);
@@ -50,7 +50,7 @@ class Node extends Component {
                 <div className="col-md-12">
                     <div className="card">
                         <div className="header">
-                            <h4 className="title">Node: {this.props.node.ID}</h4>
+                            <h4 className="title">Client: {this.props.node.Name}</h4>
                         </div>
                         <div className="content">
                             <Tabs children={this.props.children} tabs={this.state.tabs} tabSlug={tabSlug} basePath={basePath} />
@@ -67,4 +67,4 @@ function mapStateToProps({ node }) {
 }
 
 
-export default connect(mapStateToProps)(Node)
+export default connect(mapStateToProps)(Client)

--- a/frontend/src/containers/clients.js
+++ b/frontend/src/containers/clients.js
@@ -4,7 +4,7 @@ import { NomadLink } from '../components/link'
 import DisplayBoolean from '../components/display/boolean'
 import DisplayNodeStatus from '../components/display/node_status'
 
-class Nodes extends Component {
+class Clients extends Component {
 
     render() {
         return (
@@ -12,18 +12,18 @@ class Nodes extends Component {
                 <div className="col-md-12">
                     <div className="card">
                         <div className="header">
-                            <h4 className="title">Nodes</h4>
+                            <h4 className="title">Clients</h4>
                         </div>
                         <div className="content table-responsive table-full-width">
                             <table className="table table-hover table-striped">
                                 <thead>
                                     <tr>
                                         <th>ID</th>
-                                        <th>Datacenter</th>
                                         <th>Name</th>
-                                        <th>Class</th>
-                                        <th>Drain</th>
                                         <th>Status</th>
+                                        <th>Drain</th>
+                                        <th>Datacenter</th>
+                                        <th>Class</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -31,11 +31,11 @@ class Nodes extends Component {
                                         return (
                                             <tr key={node.ID}>
                                                 <td><NomadLink nodeId={node.ID} short="true"/></td>
-                                                <td>{node.Datacenter}</td>
                                                 <td>{node.Name}</td>
-                                                <td>{node.Class ? node.Class : "<none>"}</td>
-                                                <td><DisplayBoolean value={node.Drain} /></td>
                                                 <td><DisplayNodeStatus value={node.Status}/></td>
+                                                <td><DisplayBoolean value={node.Drain} /></td>
+                                                <td>{node.Datacenter}</td>
+                                                <td>{node.Class ? node.Class : "<none>"}</td>
                                             </tr>
                                         )
                                     })}
@@ -53,4 +53,4 @@ function mapStateToProps({ nodes }) {
     return { nodes }
 }
 
-export default connect(mapStateToProps)(Nodes)
+export default connect(mapStateToProps)(Clients)

--- a/frontend/src/containers/cluster.js
+++ b/frontend/src/containers/cluster.js
@@ -124,10 +124,10 @@ class Cluster extends Component {
                 <Statistics />
                 <div className="row">
                     <div className="col-md-3">
-                        <Doughnut title="Member Status" data={memberStatus} />
+                        <Doughnut title="Server Status" data={memberStatus} />
                     </div>
                     <div className="col-md-3">
-                        <Doughnut title="Node Status" data={nodeStatus} />
+                        <Doughnut title="Client Status" data={nodeStatus} />
                     </div>
                     <div className="col-md-3">
                         <Doughnut title="Job Status" data={jobStatus} />

--- a/frontend/src/containers/server.js
+++ b/frontend/src/containers/server.js
@@ -50,7 +50,7 @@ class Server extends Component {
                 <div className="col-md-12">
                     <div className="card">
                         <div className="header">
-                            <h4 className="title">Server: {this.props.member.ID}</h4>
+                            <h4 className="title">Server: {this.props.member.Name}</h4>
                         </div>
                         <div className="content">
                             <Tabs children={this.props.children} tabs={this.state.tabs} tabSlug={tabSlug} basePath={basePath} />

--- a/frontend/src/containers/server.js
+++ b/frontend/src/containers/server.js
@@ -5,7 +5,7 @@ import Tabs from '../components/tabs'
 
 import { WATCH_MEMBER, UNWATCH_MEMBER } from '../sagas/event';
 
-class Member extends Component {
+class Server extends Component {
 
     constructor(props) {
         super(props);
@@ -50,7 +50,7 @@ class Member extends Component {
                 <div className="col-md-12">
                     <div className="card">
                         <div className="header">
-                            <h4 className="title">Member: {this.props.member.ID}</h4>
+                            <h4 className="title">Server: {this.props.member.ID}</h4>
                         </div>
                         <div className="content">
                             <Tabs children={this.props.children} tabs={this.state.tabs} tabSlug={tabSlug} basePath={basePath} />
@@ -66,4 +66,4 @@ function mapStateToProps({ member }) {
     return { member }
 }
 
-export default connect(mapStateToProps)(Member)
+export default connect(mapStateToProps)(Server)

--- a/frontend/src/containers/servers.js
+++ b/frontend/src/containers/servers.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { NomadLink } from '../components/link'
 import DisplayBoolean from '../components/display/boolean'
 
-class Members extends Component {
+class Servers extends Component {
 
     render() {
         const leader = this.props.members[0]
@@ -12,7 +12,7 @@ class Members extends Component {
                 <div className="col-md-12">
                     <div className="card">
                         <div className="header">
-                            <h4 className="title">Members</h4>
+                            <h4 className="title">Servers</h4>
                         </div>
                         <div className="content table-responsive table-full-width">
                             <table className="table table-hover table-striped">
@@ -62,4 +62,4 @@ function mapStateToProps({ members }) {
     return { members }
 }
 
-export default connect(mapStateToProps)(Members)
+export default connect(mapStateToProps)(Servers)

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -25,16 +25,15 @@ import EvalInfo from './components/evaluation/info';
 import EvalAlloc from './components/evaluation/allocs';
 import EvalRaw from './components/evaluation/raw';
 
-import Nodes from './containers/nodes';
-import Node from './containers/node';
-import NodeInfo from './components/node/info';
-import NodeRaw from './components/node/raw';
+import Clients from './containers/clients';
+import Client from './containers/client';
+import ClientInfo from './components/client/info';
+import ClientRaw from './components/client/raw';
 
-import Members from './containers/members';
-import Member from './containers/member';
-import MemberInfo from './components/member/info';
-import MemberRaw from './components/member/raw';
-
+import Servers from './containers/servers';
+import Server from './containers/server';
+import ServerInfo from './components/server/info';
+import ServerRaw from './components/server/raw';
 
 class AppRouter extends Component {
 
@@ -45,11 +44,11 @@ class AppRouter extends Component {
                     <IndexRedirect to="/cluster" />
                     <Route path="/cluster" component={Cluster} />
 
-                    <Route path="/members" component={Members} />
-                    <Route path="/members/:memberId" component={Member}>
-                        <IndexRedirect to="/members/:memberId/info" />
-                        <Route path="/members/:memberId/info" component={MemberInfo} />
-                        <Route path="/members/:memberId/raw" component={MemberRaw} />
+                    <Route path="/servers" component={Servers} />
+                    <Route path="/servers/:memberId" component={Server}>
+                        <IndexRedirect to="/servers/:memberId/info" />
+                        <Route path="/servers/:memberId/info" component={ServerInfo} />
+                        <Route path="/servers/:memberId/raw" component={ServerRaw} />
                     </Route>
 
                     <Route path="/jobs" component={Jobs} />
@@ -63,11 +62,11 @@ class AppRouter extends Component {
                         <Route path="/jobs/:jobId/raw" component={JobRaw} />
                     </Route>
 
-                    <Route path="/nodes" component={Nodes} />
-                    <Route path="/nodes/:nodeId" component={Node}>
-                        <IndexRedirect to="/nodes/:nodeId/info" />
-                        <Route path="/nodes/:nodeId/info" component={NodeInfo} />
-                        <Route path="/nodes/:nodeId/raw" component={NodeRaw} />
+                    <Route path="/clients" component={Clients} />
+                    <Route path="/clients/:nodeId" component={Client}>
+                        <IndexRedirect to="/clients/:nodeId/info" />
+                        <Route path="/clients/:nodeId/info" component={ClientInfo} />
+                        <Route path="/clients/:nodeId/raw" component={ClientRaw} />
                     </Route>
 
                     <Route path="/allocations" component={Allocations} />


### PR DESCRIPTION
- Rename `member` to `server`
- Rename `node` to `client`
- Fix left-menu getting truncated when right-content got too long
- Added initial rendering of constraints (as table and as tooltip)

**note** only URL and UI have been aligned with [the official documentation](https://www.nomadproject.io/docs/cluster/bootstrapping.html) - so the js will still refer to `member` and `node` like before.

The assumption is that the UI consumer knows the docs, but not the API, and thus know of `server` and `clients`, where developers know the API gritty details, and will prefer referencing them by their implementation names