### PR TITLE
refactor allocation list UX

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
       'no-console': 0,
       'max-len': ['error', 120],
       'react/jsx-indent': ['error', 2],
+      'react/prefer-stateless-function': 0,
       'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.js'] }],
       'react/jsx-curly-spacing': [2, 'always', { 'spacing': { 'objectLiterals': 'never' }}],
       'react/self-closing-comp': ['error', { 'component': true, 'html': false }],

--- a/frontend/assets/sass/nomad-ui.scss
+++ b/frontend/assets/sass/nomad-ui.scss
@@ -79,3 +79,7 @@ dd, dt {
 	border-bottom: 1px dashed #999;
 	text-decoration: none;
 }
+
+.no-border {
+	border: none
+}

--- a/frontend/assets/sass/nomad-ui.scss
+++ b/frontend/assets/sass/nomad-ui.scss
@@ -83,3 +83,7 @@ dd, dt {
 .no-border {
 	border: none
 }
+
+.btn.no-border {
+	padding: 0
+}

--- a/frontend/assets/sass/nomad-ui/_dropdown.scss
+++ b/frontend/assets/sass/nomad-ui/_dropdown.scss
@@ -63,31 +63,6 @@
         right: 12px;
     }
 
-    .dropup &:before{
-        border-bottom: none;
-        border-top: 11px solid rgba(0, 0, 0, 0.2);
-        border-left: 11px solid rgba(0, 0, 0, 0);
-        border-right: 11px solid rgba(0, 0, 0, 0);
-        content: "";
-        display: inline-block;
-        position: absolute;
-        left: 12px;
-        top: auto;
-        bottom: -11px;
-    }
-    .dropup &:after {
-        border-bottom: none;
-        border-top: 11px solid #FFFFFF;
-        border-left: 11px solid rgba(0, 0, 0, 0);
-        border-right: 11px solid rgba(0, 0, 0, 0);
-        content: "";
-        display: inline-block;
-        position: absolute;
-        left: 12px;
-        top: auto;
-        bottom: -10px;
-    }
-
     &.dropdown-blue > li > a:hover,
     &.dropdown-blue > li > a:focus,
     &.dropdown-blue > li.selected > a{

--- a/frontend/assets/sass/nomad-ui/_dropdown.scss
+++ b/frontend/assets/sass/nomad-ui/_dropdown.scss
@@ -54,27 +54,6 @@
         color: #333333;
     }
 
-    &:before{
-        border-bottom: 11px solid rgba(0, 0, 0, 0.2);
-        border-left: 11px solid rgba(0, 0, 0, 0);
-        border-right: 11px solid rgba(0, 0, 0, 0);
-        content: "";
-        display: inline-block;
-        position: absolute;
-        left: 12px;
-        top: -11px;
-    }
-    &:after {
-        border-bottom: 11px solid #FFFFFF;
-        border-left: 11px solid rgba(0, 0, 0, 0);
-        border-right: 11px solid rgba(0, 0, 0, 0);
-        content: "";
-        display: inline-block;
-        position: absolute;
-        left: 12px;
-        top: -10px;
-    }
-
     .pull-right &:before{
         left: auto;
         right: 12px;

--- a/frontend/assets/sass/nomad-ui/_variables.scss
+++ b/frontend/assets/sass/nomad-ui/_variables.scss
@@ -119,7 +119,7 @@ $primary-color:              $color-blue !default;
 $primary-bg:                 $color-blue !default;
 $primary-states-color:       darken($color-blue, 5%) !default;
 
-$info-color:                 #449b82 !default;
+$info-color:                 #49a98d;
 $info-bg:                    $color-azure !default;
 $info-states-color:          darken(#449b82, 6%) !default;
 

--- a/frontend/src/components/allocation/list.js
+++ b/frontend/src/components/allocation/list.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { DropdownButton } from 'react-bootstrap';
+import { DropdownButton, Glyphicon } from 'react-bootstrap';
 import NomadLink from '../link';
 import FormatTime from '../format/time';
 import shortUUID from '../../helpers/uuid';
@@ -17,38 +17,93 @@ const getAllocationNumberFromName = (allocationName) => {
     return match[0];
 };
 
-const AllocationList = ({ allocations, nodes }) =>
+const optionsGlyph = <Glyphicon glyph="option-vertical" />;
+
+const jobHeaderColumn = (display) => {
+    let output;
+
+    if (display) {
+        output = <th>Job</th>;
+    }
+
+    return output;
+};
+
+const jobColumn = (allocation, display) => {
+    let output;
+
+    if (display) {
+        output = <td><NomadLink jobId={ allocation.JobID } short="true" /></td>;
+    }
+
+    return output;
+};
+
+const clientHeaderColumn = (display) => {
+    let output;
+
+    if (display) {
+        output = <th>Client</th>;
+    }
+
+    return output;
+};
+
+const clientColumn = (allocation, nodes, display) => {
+    let output;
+
+    if (display) {
+        output = <td><NomadLink nodeId={ allocation.NodeID } nodeList={ nodes } short="true" /></td>;
+    }
+
+    return output;
+};
+
+const AllocationList = ({ allocations, nodes, showJobColumn, showClientColumn }) =>
   <table className="table table-hover table-striped">
     <thead>
       <tr>
         <th></th>
         <th>ID</th>
-        <th>Job</th>
+        { jobHeaderColumn(showJobColumn) }
         <th>Task Group</th>
-        <th>Client</th>
         <th>Client Status</th>
-        <th>When</th>
+        { clientHeaderColumn(showClientColumn) }
+        <th>Age</th>
+        <th></th>
         <th></th>
       </tr>
     </thead>
     <tbody>
-      { allocations.map((allocation) => {
+      {allocations.map((allocation) => {
           const color = allocationStatusColors[allocation.ClientStatus];
           return (
             <tr className={ color } key={ allocation.ID }>
               <td>{ renderClientStatus(allocation) }</td>
               <td><NomadLink allocId={ allocation.ID } short="true" /></td>
-              <td><NomadLink jobId={ allocation.JobID } short="true" /></td>
+              { jobColumn(allocation, showJobColumn, nodes) }
               <td>
                 <NomadLink jobId={ allocation.JobID } taskGroupId={ allocation.TaskGroupId }>
                   { allocation.TaskGroup } ({ getAllocationNumberFromName(allocation.Name) })
                 </NomadLink>
               </td>
-              <td><NomadLink nodeId={ allocation.NodeID } nodeList={ nodes } short="true" /></td>
               <td>{ renderDesiredStatus(allocation) }</td>
+              { clientColumn(allocation, nodes, showClientColumn) }
               <td><FormatTime time={ allocation.CreateTime } /></td>
               <td>
-                <DropdownButton bsSize="small" title="more" key={ allocation.Name } id={ `actions-${allocation.Name}` }>
+                <NomadLink allocId={ allocation.ID } linkAppend="/files?path=/alloc/logs/">
+                  <Glyphicon glyph="align-left" />
+                </NomadLink>
+              </td>
+              <td>
+                <DropdownButton
+                  noCaret
+                  pullRight
+                  className="no-border pull-right"
+                  title={ optionsGlyph }
+                  key={ allocation.Name }
+                  id={ `actions-${allocation.Name}` }
+                >
                   <li>
                     <NomadLink role="menuitem" evalId={ allocation.EvalID }>
                       Allocation <code>{ shortUUID(allocation.EvalID) }</code>
@@ -57,11 +112,6 @@ const AllocationList = ({ allocations, nodes }) =>
                   <li>
                     <NomadLink role="menuitem" allocId={ allocation.ID } linkAppend="/files">
                       Files
-                    </NomadLink>
-                  </li>
-                  <li>
-                    <NomadLink role="menuitem" allocId={ allocation.ID } linkAppend="/files?path=/alloc/logs/">
-                      Logs
                     </NomadLink>
                   </li>
                   <li>
@@ -77,9 +127,19 @@ const AllocationList = ({ allocations, nodes }) =>
     </tbody>
   </table>;
 
+AllocationList.defaultProps = {
+    allocation: {},
+    nodes: {},
+
+    showJobColumn: true,
+    showClientColumn: true,
+};
+
 AllocationList.propTypes = {
     allocations: PropTypes.array.isRequired,
     nodes: PropTypes.array.isRequired,
+    showJobColumn: PropTypes.bool.isRequired,
+    showClientColumn: PropTypes.bool.isRequired,
 };
 
 export default AllocationList;

--- a/frontend/src/components/allocation/list.js
+++ b/frontend/src/components/allocation/list.js
@@ -129,8 +129,8 @@ const AllocationList = ({ allocations, nodes, showJobColumn, showClientColumn })
   </table>;
 
 AllocationList.defaultProps = {
-    allocation: {},
-    nodes: {},
+    allocation: [],
+    nodes: [],
 
     showJobColumn: true,
     showClientColumn: true,

--- a/frontend/src/components/allocation/list.js
+++ b/frontend/src/components/allocation/list.js
@@ -75,7 +75,7 @@ const AllocationList = ({ allocations, nodes, showJobColumn, showClientColumn })
       </tr>
     </thead>
     <tbody>
-      {allocations.map((allocation) => {
+      {allocations.map((allocation, index) => {
           const color = allocationStatusColors[allocation.ClientStatus];
           return (
             <tr className={ color } key={ allocation.ID }>
@@ -99,6 +99,7 @@ const AllocationList = ({ allocations, nodes, showJobColumn, showClientColumn })
                 <DropdownButton
                   noCaret
                   pullRight
+                  dropup={ index > allocations.length - 4 }
                   className="no-border pull-right"
                   title={ optionsGlyph }
                   key={ allocation.Name }

--- a/frontend/src/components/allocation/list.js
+++ b/frontend/src/components/allocation/list.js
@@ -19,45 +19,17 @@ const getAllocationNumberFromName = (allocationName) => {
 
 const optionsGlyph = <Glyphicon glyph="option-vertical" />;
 
-const jobHeaderColumn = (display) => {
-    let output;
+const jobHeaderColumn = display =>
+    (display ? <th>Job</th> : null);
 
-    if (display) {
-        output = <th>Job</th>;
-    }
+const jobColumn = (allocation, display) =>
+    (display ? <td><NomadLink jobId={ allocation.JobID } short="true" /></td> : null);
 
-    return output;
-};
+const clientHeaderColumn = display =>
+    (display ? <th>Client</th> : null);
 
-const jobColumn = (allocation, display) => {
-    let output;
-
-    if (display) {
-        output = <td><NomadLink jobId={ allocation.JobID } short="true" /></td>;
-    }
-
-    return output;
-};
-
-const clientHeaderColumn = (display) => {
-    let output;
-
-    if (display) {
-        output = <th>Client</th>;
-    }
-
-    return output;
-};
-
-const clientColumn = (allocation, nodes, display) => {
-    let output;
-
-    if (display) {
-        output = <td><NomadLink nodeId={ allocation.NodeID } nodeList={ nodes } short="true" /></td>;
-    }
-
-    return output;
-};
+const clientColumn = (allocation, nodes, display) =>
+    (display ? <td><NomadLink nodeId={ allocation.NodeID } nodeList={ nodes } short="true" /></td> : null);
 
 const AllocationList = ({ allocations, nodes, showJobColumn, showClientColumn }) =>
   <table className="table table-hover table-striped">

--- a/frontend/src/components/allocation/list.js
+++ b/frontend/src/components/allocation/list.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { DropdownButton, Glyphicon } from 'react-bootstrap';
+import { Link } from 'react-router';
 import NomadLink from '../link';
 import FormatTime from '../format/time';
 import shortUUID from '../../helpers/uuid';
@@ -31,78 +32,113 @@ const clientHeaderColumn = display =>
 const clientColumn = (allocation, nodes, display) =>
     (display ? <td><NomadLink nodeId={ allocation.NodeID } nodeList={ nodes } short="true" /></td> : null);
 
-const AllocationList = ({ allocations, nodes, showJobColumn, showClientColumn }) =>
-  <table className="table table-hover table-striped">
-    <thead>
-      <tr>
-        <th></th>
-        <th>ID</th>
-        { jobHeaderColumn(showJobColumn) }
-        <th>Task Group</th>
-        <th>Client Status</th>
-        { clientHeaderColumn(showClientColumn) }
-        <th>Age</th>
-        <th></th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      {allocations.map((allocation, index) => {
-          const color = allocationStatusColors[allocation.ClientStatus];
-          return (
-            <tr className={ color } key={ allocation.ID }>
-              <td>{ renderClientStatus(allocation) }</td>
-              <td><NomadLink allocId={ allocation.ID } short="true" /></td>
-              { jobColumn(allocation, showJobColumn, nodes) }
-              <td>
-                <NomadLink jobId={ allocation.JobID } taskGroupId={ allocation.TaskGroupId }>
-                  { allocation.TaskGroup } ({ getAllocationNumberFromName(allocation.Name) })
-                </NomadLink>
-              </td>
-              <td>{ renderDesiredStatus(allocation) }</td>
-              { clientColumn(allocation, nodes, showClientColumn) }
-              <td><FormatTime time={ allocation.CreateTime } /></td>
-              <td>
-                <NomadLink allocId={ allocation.ID } linkAppend="/files?path=/alloc/logs/">
-                  <Glyphicon glyph="align-left" />
-                </NomadLink>
-              </td>
-              <td>
-                <DropdownButton
-                  noCaret
-                  pullRight
-                  dropup={ index > allocations.length - 4 }
-                  className="no-border pull-right"
-                  title={ optionsGlyph }
-                  key={ allocation.Name }
-                  id={ `actions-${allocation.Name}` }
-                >
-                  <li>
-                    <NomadLink role="menuitem" evalId={ allocation.EvalID }>
-                      Allocation <code>{ shortUUID(allocation.EvalID) }</code>
-                    </NomadLink>
-                  </li>
-                  <li>
-                    <NomadLink role="menuitem" allocId={ allocation.ID } linkAppend="/files">
-                      Files
-                    </NomadLink>
-                  </li>
-                  <li>
-                    <NomadLink role="menuitem" allocId={ allocation.ID }>
-                      Task States
-                    </NomadLink>
-                  </li>
-                </DropdownButton>
-              </td>
-            </tr>
-          );
-      })}
-    </tbody>
-  </table>;
+class AllocationList extends Component {
+
+    filteredAllocations() {
+        const query = this.props.location.query || {};
+        let allocations = this.props.allocations;
+
+        if ('status' in query) {
+            allocations = allocations.filter(allocation => allocation.ClientStatus === query.status);
+        }
+
+        if ('job' in query) {
+            allocations = allocations.filter(allocation => allocation.JobID === query.job);
+        }
+
+        return allocations;
+    }
+
+    render() {
+        const showJobColumn = this.props.showJobColumn;
+        const showClientColumn = this.props.showClientColumn;
+        const allocations = this.props.allocations;
+        const nodes = this.props.nodes;
+
+        return (
+          <div>
+            <DropdownButton title="Client Status" key="filter-client-status" id="filter-client-status">
+              <li><Link to={ location.pathname } query={{ status: 'running' }}>Running</Link></li>
+              <li><Link to={ location.pathname } query={{ status: 'complete' }}>Complete</Link></li>
+              <li><Link to={ location.pathname } query={{ status: 'lost' }}>Lost</Link></li>
+              <li><Link to={ location.pathname } query={{ status: 'failed' }}>Failed</Link></li>
+            </DropdownButton>
+
+            <table className="table table-hover table-striped">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>ID</th>
+                  { jobHeaderColumn(showJobColumn) }
+                  <th>Task Group</th>
+                  <th>Client Status</th>
+                  { clientHeaderColumn(showClientColumn) }
+                  <th>Age</th>
+                  <th></th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {this.filteredAllocations().map((allocation, index) => {
+                    const color = allocationStatusColors[allocation.ClientStatus];
+                    return (
+                      <tr className={ color } key={ allocation.ID }>
+                        <td>{ renderClientStatus(allocation) }</td>
+                        <td><NomadLink allocId={ allocation.ID } short="true" /></td>
+                        { jobColumn(allocation, showJobColumn, nodes) }
+                        <td>
+                          <NomadLink jobId={ allocation.JobID } taskGroupId={ allocation.TaskGroupId }>
+                            { allocation.TaskGroup } ({ getAllocationNumberFromName(allocation.Name) })
+                          </NomadLink>
+                        </td>
+                        <td>{ renderDesiredStatus(allocation) }</td>
+                        { clientColumn(allocation, nodes, showClientColumn) }
+                        <td><FormatTime time={ allocation.CreateTime } /></td>
+                        <td>
+                          <NomadLink allocId={ allocation.ID } linkAppend="/files?path=/alloc/logs/">
+                            <Glyphicon glyph="align-left" />
+                          </NomadLink>
+                        </td>
+                        <td>
+                          <DropdownButton
+                            noCaret
+                            pullRight
+                            dropup={ index > allocations.length - 4 }
+                            className="no-border pull-right"
+                            title={ optionsGlyph }
+                            key={ allocation.Name }
+                            id={ `actions-${allocation.Name}` }
+                          >
+                            <li>
+                              <NomadLink role="menuitem" evalId={ allocation.EvalID }>
+                                Allocation <code>{ shortUUID(allocation.EvalID) }</code>
+                              </NomadLink>
+                            </li>
+                            <li>
+                              <NomadLink role="menuitem" allocId={ allocation.ID } linkAppend="/files">
+                                Files
+                              </NomadLink>
+                            </li>
+                            <li>
+                              <NomadLink role="menuitem" allocId={ allocation.ID }>
+                                Task States
+                              </NomadLink>
+                            </li>
+                          </DropdownButton>
+                        </td>
+                      </tr>
+                    );
+                })}
+              </tbody>
+            </table>
+          </div>);
+    }
+}
 
 AllocationList.defaultProps = {
     allocation: [],
     nodes: [],
+    location: {},
 
     showJobColumn: true,
     showClientColumn: true,
@@ -111,6 +147,8 @@ AllocationList.defaultProps = {
 AllocationList.propTypes = {
     allocations: PropTypes.array.isRequired,
     nodes: PropTypes.array.isRequired,
+    location: PropTypes.object.isRequired,
+
     showJobColumn: PropTypes.bool.isRequired,
     showClientColumn: PropTypes.bool.isRequired,
 };

--- a/frontend/src/components/app.js
+++ b/frontend/src/components/app.js
@@ -1,17 +1,23 @@
-import React, { PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import Sidebar from './sidebar';
 
-const App = ({ location, children }) =>
-  <div className="row">
-    <Sidebar location={ location } />
-    <div className="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main-panel">
-      <div className="content">
-        <div className="container-fluid">
-          { children }
-        </div>
-      </div>
-    </div>
-  </div>;
+class App extends PureComponent {
+
+    render() {
+        return (
+          <div className="row">
+            <Sidebar location={ this.props.location } />
+            <div className="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main-panel">
+              <div className="content">
+                <div className="container-fluid">
+                  { this.props.children }
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+    }
+}
 
 App.propTypes = {
     location: PropTypes.object.isRequired,

--- a/frontend/src/components/client/allocations.js
+++ b/frontend/src/components/client/allocations.js
@@ -1,0 +1,31 @@
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import AllocationList from '../allocation/list';
+
+const ClientAllocations = ({ allocations, node, nodes }) => {
+    const allocs = allocations.filter(allocation =>
+        allocation.NodeID === node.ID
+    );
+
+    return (
+      <div className="tab-pane active">
+        <AllocationList showClientColumn={ false } allocations={ allocs } nodes={ nodes } />
+      </div>
+    );
+};
+
+function mapStateToProps({ allocations, node, nodes }) {
+    return { allocations, node, nodes };
+}
+
+ClientAllocations.defaultProps = {
+    allocations: [],
+    node: [],
+};
+
+ClientAllocations.propTypes = {
+    allocations: PropTypes.array.isRequired,
+    nodes: PropTypes.array.isRequired,
+};
+
+export default connect(mapStateToProps)(ClientAllocations);

--- a/frontend/src/components/client/allocations.js
+++ b/frontend/src/components/client/allocations.js
@@ -2,30 +2,30 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import AllocationList from '../allocation/list';
 
-const ClientAllocations = ({ allocations, node, nodes }) => {
+const ClientAllocations = ({ allocations, node }) => {
     const allocs = allocations.filter(allocation =>
         allocation.NodeID === node.ID
     );
 
     return (
       <div className="tab-pane active">
-        <AllocationList showClientColumn={ false } allocations={ allocs } nodes={ nodes } />
+        <AllocationList showClientColumn={ false } allocations={ allocs } />
       </div>
     );
 };
 
-function mapStateToProps({ allocations, node, nodes }) {
-    return { allocations, node, nodes };
+function mapStateToProps({ allocations, node }) {
+    return { allocations, node };
 }
 
 ClientAllocations.defaultProps = {
     allocations: [],
-    node: [],
+    node: {},
 };
 
 ClientAllocations.propTypes = {
     allocations: PropTypes.array.isRequired,
-    nodes: PropTypes.array.isRequired,
+    node: PropTypes.object.isRequired,
 };
 
 export default connect(mapStateToProps)(ClientAllocations);

--- a/frontend/src/components/client/evaluations.js
+++ b/frontend/src/components/client/evaluations.js
@@ -1,0 +1,33 @@
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import EvaluationList from '../evaluation/list';
+
+const ClientEvaluations = ({ evaluations, node, nodes }) => {
+    const evals = evaluations.filter(evaluation =>
+        evaluation.NodeID === node.ID
+    );
+
+    return (
+      <div className="tab-pane active">
+        <EvaluationList evaluations={ evals } nodes={ nodes } />
+      </div>
+    );
+};
+
+function mapStateToProps({ evaluations, node, nodes }) {
+    return { evaluations, node, nodes };
+}
+
+ClientEvaluations.defaultProps = {
+    evaluations: [],
+    nodes: [],
+    node: {},
+};
+
+ClientEvaluations.propTypes = {
+    evaluations: PropTypes.array.isRequired,
+    nodes: PropTypes.array.isRequired,
+    node: PropTypes.object.isRequired,
+};
+
+export default connect(mapStateToProps)(ClientEvaluations);

--- a/frontend/src/components/client/evaluations.js
+++ b/frontend/src/components/client/evaluations.js
@@ -2,31 +2,29 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import EvaluationList from '../evaluation/list';
 
-const ClientEvaluations = ({ evaluations, node, nodes }) => {
+const ClientEvaluations = ({ evaluations, node }) => {
     const evals = evaluations.filter(evaluation =>
         evaluation.NodeID === node.ID
     );
 
     return (
       <div className="tab-pane active">
-        <EvaluationList evaluations={ evals } nodes={ nodes } />
+        <EvaluationList evaluations={ evals } />
       </div>
     );
 };
 
-function mapStateToProps({ evaluations, node, nodes }) {
-    return { evaluations, node, nodes };
+function mapStateToProps({ evaluations, node }) {
+    return { evaluations, node, nodes: [] };
 }
 
 ClientEvaluations.defaultProps = {
     evaluations: [],
-    nodes: [],
     node: {},
 };
 
 ClientEvaluations.propTypes = {
     evaluations: PropTypes.array.isRequired,
-    nodes: PropTypes.array.isRequired,
     node: PropTypes.object.isRequired,
 };
 

--- a/frontend/src/components/evaluation/list.js
+++ b/frontend/src/components/evaluation/list.js
@@ -29,6 +29,11 @@ const EvaluationList = ({ evaluations, nodes }) =>
     </tbody>
   </table>;
 
+EvaluationList.defaultProps = {
+    evaluations: [],
+    nodes: [],
+};
+
 EvaluationList.propTypes = {
     evaluations: PropTypes.array.isRequired,
     nodes: PropTypes.array.isRequired,

--- a/frontend/src/components/format/time.js
+++ b/frontend/src/components/format/time.js
@@ -15,7 +15,7 @@ class FormatTime extends Component {
                 .format(this.props.durationFormat, { forceLength: true });
         }
 
-        return time.from(now);
+        return time.from(now, true);
     }
 
     render() {

--- a/frontend/src/components/job/allocs.js
+++ b/frontend/src/components/job/allocs.js
@@ -9,7 +9,7 @@ const JobAllocs = ({ allocations, nodes, job }) => {
 
     return (
       <div className="tab-pane active">
-        <AllocationList allocations={ allocs } nodes={ nodes } />
+        <AllocationList showJobColumn={ false } allocations={ allocs } nodes={ nodes } />
       </div>
     );
 };

--- a/frontend/src/components/job/info.js
+++ b/frontend/src/components/job/info.js
@@ -12,6 +12,7 @@ class JobInfo extends Component {
     render() {
         const tasks = [];
         const job = this.props.job;
+        const jobMetaBag = job.Meta || {};
 
         // Build the task groups table
         const taskGroups = job.TaskGroups.map((taskGroup) => {
@@ -38,6 +39,7 @@ class JobInfo extends Component {
                 return null;
             });
 
+            const taskGroupMeta = taskGroup.Meta || {};
             return (
               <tr key={ taskGroup.ID }>
                 <td>
@@ -47,7 +49,7 @@ class JobInfo extends Component {
                 </td>
                 <td>{ taskGroup.Count }</td>
                 <td>{ taskGroup.Tasks.length }</td>
-                <td><MetaDisplay asTooltip metaBag={ taskGroup.Meta } /></td>
+                <td><MetaDisplay asTooltip metaBag={ taskGroupMeta } /></td>
                 <td>{ taskGroup.RestartPolicy.Mode }</td>
                 <td><ConstraintTable idPrefix={ taskGroup.ID } asTooltip constraints={ taskGroup.Constraints } /></td>
               </tr>
@@ -79,7 +81,7 @@ class JobInfo extends Component {
 
                 <div className="col-lg-6 col-md-6 col-sm-12 col-sx-12">
                   <legend>Meta Properties</legend>
-                  <MetaDisplay dtWithClass="wide" metaBag={ this.props.job.Meta } />
+                  <MetaDisplay dtWithClass="wide" metaBag={ jobMetaBag } />
                 </div>
               </div>
 

--- a/frontend/src/components/link.js
+++ b/frontend/src/components/link.js
@@ -138,6 +138,7 @@ NomadLink.propTypes = {
     children: PropTypes.oneOfType([
         PropTypes.array,
         PropTypes.string,
+        React.PropTypes.node,
     ]),
     memberId: PropTypes.string,
     nodeId: PropTypes.string,

--- a/frontend/src/components/meta.js
+++ b/frontend/src/components/meta.js
@@ -5,7 +5,7 @@ import uuid from 'node-uuid';
 class Meta extends Component {
 
     render() {
-        const metaBag = this.props.metaBag;
+        const metaBag = this.props.metaBag || {};
         const dtWithClass = this.props.dtWithClass;
         const sortKeys = this.props.sortKeys;
         const asTooltip = this.props.asTooltip;

--- a/frontend/src/containers/allocations.js
+++ b/frontend/src/containers/allocations.js
@@ -1,22 +1,28 @@
-import React, { PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import AllocationList from '../components/allocation/list';
 
-const Allocations = ({ allocations, nodes }) =>
-  <div className="row">
-    <div className="col-md-12">
-      <div className="card">
-        <div className="header">
-          <h4 className="title">
-            Allocations
-          </h4>
-        </div>
-        <div className="content table-responsive table-full-width">
-          <AllocationList allocations={ allocations } nodes={ nodes } />
-        </div>
-      </div>
-    </div>
-  </div>;
+class Allocations extends PureComponent {
+
+    render() {
+        return (
+          <div className="row">
+            <div className="col-md-12">
+              <div className="card">
+                <div className="header">
+                  <h4 className="title">
+                    Allocations
+                  </h4>
+                </div>
+                <div className="content table-responsive table-full-width">
+                  <AllocationList { ...this.props } allocations={ this.props.allocations } nodes={ this.props.nodes } />
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+    }
+}
 
 function mapStateToProps({ allocations, nodes }) {
     return { allocations, nodes };

--- a/frontend/src/containers/client.js
+++ b/frontend/src/containers/client.js
@@ -17,6 +17,14 @@ class Client extends Component {
                     path: 'info',
                 },
                 {
+                    name: 'Allocations',
+                    path: 'allocations',
+                },
+                {
+                    name: 'Evaluations',
+                    path: 'evaluations',
+                },
+                {
                     name: 'Raw',
                     path: 'raw',
                 },

--- a/frontend/src/helpers/render/allocation.js
+++ b/frontend/src/helpers/render/allocation.js
@@ -2,18 +2,11 @@ import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import { Glyphicon } from 'react-bootstrap';
 
-const clientStatusTextColor = {
-    xcomplete: 'text-success',
-    xrunning: 'text-info',
-    xlost: 'text-warning',
-    xfailed: 'text-danger',
-};
-
 const clientStatusIcon = {
-    complete: <Glyphicon glyph="ok" />,
-    running: <Glyphicon glyph="cog" />,
-    lost: <Glyphicon glyph="remove" />,
-    failed: <Glyphicon glyph="exclamation-sign" />,
+    complete: <span><Glyphicon glyph="stop" /></span>,
+    running: <span className="text-success"><Glyphicon glyph="play" /></span>,
+    lost: <span className="text-danger"><Glyphicon glyph="remove" /></span>,
+    failed: <span className="text-danger"><Glyphicon glyph="exclamation-sign" /></span>,
 };
 
 export function renderDesiredStatus(allocation) {
@@ -32,12 +25,7 @@ export function renderDesiredStatus(allocation) {
 }
 
 export function renderClientStatus(allocation) {
-    let textColor = null;
     let icon = null;
-
-    if (allocation.ClientStatus in clientStatusTextColor) {
-        textColor = clientStatusTextColor[allocation.ClientStatus];
-    }
 
     if (allocation.ClientStatus in clientStatusIcon) {
         icon = clientStatusIcon[allocation.ClientStatus];
@@ -46,7 +34,7 @@ export function renderClientStatus(allocation) {
     return (
       <div>
         <ReactTooltip id={ `client-status-${allocation.ID}` }>{allocation.ClientStatus}</ReactTooltip>
-        <span data-tip data-for={ `client-status-${allocation.ID}` } className={ textColor }>{icon}</span>
+        <span data-tip data-for={ `client-status-${allocation.ID}` }>{icon}</span>
       </div>
     );
 }

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -28,6 +28,8 @@ import EvalRaw from './components/evaluation/raw';
 import Clients from './containers/clients';
 import Client from './containers/client';
 import ClientInfo from './components/client/info';
+import ClientAllocations from './components/client/allocations';
+import ClientEvaluations from './components/client/evaluations';
 import ClientRaw from './components/client/raw';
 
 import Servers from './containers/servers';
@@ -63,6 +65,8 @@ const AppRouter = ({ history }) =>
       <Route path="/clients/:nodeId" component={ Client }>
         <IndexRedirect to="/clients/:nodeId/info" />
         <Route path="/clients/:nodeId/info" component={ ClientInfo } />
+        <Route path="/clients/:nodeId/allocations" component={ ClientAllocations } />
+        <Route path="/clients/:nodeId/evaluations" component={ ClientEvaluations } />
         <Route path="/clients/:nodeId/raw" component={ ClientRaw } />
       </Route>
 


### PR DESCRIPTION
before / after in `job` context

![image](https://cloud.githubusercontent.com/assets/22841/19120902/dee502f6-8b24-11e6-932c-3919e3932a52.png)

before/after in global `allocations` context

![image](https://cloud.githubusercontent.com/assets/22841/19121077/6d0f72e6-8b25-11e6-8a77-d8873b04f6ef.png)


the PR also include an option to show/hide the `client` and `job` column

for example, it does not make sense to show the `job` column in the context of `/job/:id/allocations` and i personally don't think we should show the `client` column in the `/allocations` list

the small new icon links to the `/allocation/:id/files/` with deep-link into the `/alloc/logs/` directory 

i've also removed `ago` in durations, as it was just wasting space :)

the menu should also avoid being truncated to the right of the window now, as it pops out to the left now

changed order of `client` and `client status` as I feel the status is more important than where the allocation run.

my personal reasoning for wanting to hide the `client` column is that it feel like server-hugging to me to care about that. Go to the allocation if you want to see the `client`, or go to the `client` and look at it's `allocations` (to be completed :))