### PR TITLE
url-encode job URL

### DIFF
--- a/frontend/src/components/link.js
+++ b/frontend/src/components/link.js
@@ -81,7 +81,7 @@ export default class NomadLink extends Component {
         // tasks
         if (this.props.taskId !== undefined) {
             if (this.props.jobId !== undefined && this.props.taskGroupId !== undefined) {
-                const jobId = this.props.jobId;
+                const jobId = encodeURIComponent(this.props.jobId);
                 const taskGroupId = this.props.taskGroupId;
                 const taskId = this.props.taskId;
 
@@ -100,7 +100,7 @@ export default class NomadLink extends Component {
         // taskGroup (must be after task)
         if (this.props.taskGroupId !== undefined) {
             if (this.props.jobId !== undefined) {
-                const jobId = this.props.jobId;
+                const jobId = encodeURIComponent(this.props.jobId);
                 const taskGroupId = this.props.taskGroupId;
 
                 if (children === undefined) {
@@ -117,7 +117,7 @@ export default class NomadLink extends Component {
 
         // job (must be after task & taskGroup
         if (this.props.jobId !== undefined) {
-            const jobId = this.props.jobId;
+            const jobId = encodeURIComponent(this.props.jobId);
 
             if (children === undefined) {
                 children = short ? shortUUID(jobId) : jobId;

--- a/frontend/src/components/link.js
+++ b/frontend/src/components/link.js
@@ -81,7 +81,8 @@ export default class NomadLink extends Component {
         // tasks
         if (this.props.taskId !== undefined) {
             if (this.props.jobId !== undefined && this.props.taskGroupId !== undefined) {
-                const jobId = encodeURIComponent(this.props.jobId);
+                const jobId = this.props.jobId;
+                const jobIdUrl = encodeURIComponent(jobId);
                 const taskGroupId = this.props.taskGroupId;
                 const taskId = this.props.taskId;
 
@@ -89,7 +90,7 @@ export default class NomadLink extends Component {
                     children = short ? shortUUID(taskId) : taskId;
                 }
                 return (
-                  <Link { ...linkProps } to={ `/jobs/${jobId}/tasks${linkAppend}` } query={{ taskGroupId, taskId }} >
+                  <Link { ...linkProps } to={ `/jobs/${jobIdUrl}/tasks${linkAppend}` } query={{ taskGroupId, taskId }} >
                     { children }
                   </Link>
                 );
@@ -100,14 +101,15 @@ export default class NomadLink extends Component {
         // taskGroup (must be after task)
         if (this.props.taskGroupId !== undefined) {
             if (this.props.jobId !== undefined) {
-                const jobId = encodeURIComponent(this.props.jobId);
+                const jobId = this.props.jobId;
+                const jobIdUrl = encodeURIComponent(jobId);
                 const taskGroupId = this.props.taskGroupId;
 
                 if (children === undefined) {
                     children = short ? shortUUID(taskGroupId) : taskGroupId;
                 }
                 return (
-                  <Link { ...linkProps } to={ `/jobs/${jobId}/taskGroups${linkAppend}` } query={{ taskGroupId }} >
+                  <Link { ...linkProps } to={ `/jobs/${jobIdUrl}/taskGroups${linkAppend}` } query={{ taskGroupId }} >
                     { children }
                   </Link>
                 );
@@ -117,13 +119,14 @@ export default class NomadLink extends Component {
 
         // job (must be after task & taskGroup
         if (this.props.jobId !== undefined) {
-            const jobId = encodeURIComponent(this.props.jobId);
+            const jobId = this.props.jobId;
+            const jobIdUrl = encodeURIComponent(jobId);
 
             if (children === undefined) {
                 children = short ? shortUUID(jobId) : jobId;
             }
             return (
-              <Link { ...linkProps } to={ `/jobs/${jobId}${linkAppend}` }>{ children }</Link>
+              <Link { ...linkProps } to={ `/jobs/${jobIdUrl}${linkAppend}` }>{ children }</Link>
             );
         }
 


### PR DESCRIPTION
When using `periodic` Job type, the intermidiate `Job` resource created will be in the format of `${job}-{$taskGroup}-${task}/${periodic-timestamp}-${time-in-ms}` 

The slash in that Job ID will make it impossible to link to a job, since the slash is not encoded, and thus treated as part of the path, rather than the segment

This PR should resolve this :)