### PR TITLE
IE + Edge support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   "author": "Ivo Verberk",
   "license": "MIT ",
   "dependencies": {
+    "babel-polyfill": "^6.16.0",
     "babel-runtime": "^6.9.2",
     "bootstrap": "^3.3.6",
     "chart.js": "^2.1.6",

--- a/frontend/src/sagas/event.js
+++ b/frontend/src/sagas/event.js
@@ -123,7 +123,7 @@ export default function eventSaga() {
             hostname = `${location.hostname}:${process.env.GO_PORT}` || 3000;
         }
 
-        const url = `${protocol}///${hostname}/ws`;
+        const url = `${protocol}//${hostname}/ws`;
         const p = connectTo(url);
 
         return p.then((socket) => {

--- a/frontend/webpack-prod.config.js
+++ b/frontend/webpack-prod.config.js
@@ -13,6 +13,7 @@ webpackConfig = merge(webpackConfig, {
     },
     bail: true,
     entry: [
+        'babel-polyfill',
         './src/main.js'
     ],
     devtool: 'source-map',

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -10,6 +10,7 @@ webpackConfig = merge(webpackConfig, {
     entry: [
         'webpack-dev-server/client?http://localhost:3333',
         'webpack/hot/only-dev-server',
+        'babel-polyfill',
         './src/main.js'
     ],
     devtool: 'cheap-module-eval-source-map',


### PR DESCRIPTION
Fixes #116 

The root error was a third `/` in the WebSocket connection.

Also added `babel-polyfill`, since IE / Edge and possible other browsers don't like `String.startsWith` and other ES6 features :)